### PR TITLE
BMS-2055 map design types and params for analysis

### DIFF
--- a/src/main/java/org/generationcp/commons/breedingview/xml/DesignType.java
+++ b/src/main/java/org/generationcp/commons/breedingview/xml/DesignType.java
@@ -19,7 +19,7 @@ public enum DesignType {
 
 	private final String name;
 
-	private DesignType(String name) {
+	private DesignType(final String name) {
 		this.name = name;
 	}
 


### PR DESCRIPTION
This change only adds Alpha lattice as a valid design type for Trials / Nurseries in SSA. This is required by https://github.com/IntegratedBreedingPlatform/Workbench/pull/43
