### PR TITLE
BMS-3150 Cross Name Algorithm Execution Consistency

### DIFF
--- a/src/main/java/org/generationcp/commons/parsing/pojo/ImportedCrosses.java
+++ b/src/main/java/org/generationcp/commons/parsing/pojo/ImportedCrosses.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
-import org.generationcp.middleware.pojos.ListDataProject;
 
 /**
  * The Class ImportedCrosses.
@@ -105,20 +104,14 @@ public class ImportedCrosses extends ImportedGermplasm implements Serializable {
 		super(entryId, desig, gid, cross, source, entryCode, check);
 	}
 
-	public ImportedCrosses(ListDataProject femaleListData, ListDataProject maleListData, String femaleStudyName, String maleStudyName,
+	public ImportedCrosses(String femaleStudyName, String maleStudyName,
 			String femalePlotNo, String malePlotNo, int entryId) {
-		this.setFemaleDesig(femaleListData.getDesignation());
-		this.setMaleDesig(maleListData.getDesignation());
-		this.setFemaleGid(femaleListData.getGermplasmId().toString());
-		this.setMaleGid(maleListData.getGermplasmId().toString());
 		this.setFemalePlotNo(femalePlotNo);
 		this.setMalePlotNo(malePlotNo);
 		this.setEntryId(entryId);
 		this.setMaleStudyName(maleStudyName);
 		this.setFemaleStudyName(femaleStudyName);
 
-		// Parentage: "female designation / male designation"
-		this.setCross(femaleListData.getDesignation() + " / " + maleListData.getDesignation());
 	}
 
 	public void setOptionalFields(String rawBreedingMethod, Integer crossingDate, String notes) {


### PR DESCRIPTION
Removed ListDataProject from constructor of ImportedCrosses class. The parents information will be set later on after one-off query of all cross parents in list. This is part of performance improvement in querying parents on import crosses.

Issue: BMS-3247 / BMS-3150
