### PR TITLE
BMS-3528 BC Should Resolve to Only M or F

### DIFF
--- a/src/main/java/org/generationcp/commons/ruleengine/cross/BackCrossSuffixRule.java
+++ b/src/main/java/org/generationcp/commons/ruleengine/cross/BackCrossSuffixRule.java
@@ -14,8 +14,8 @@ import org.springframework.stereotype.Component;
 public class BackCrossSuffixRule extends ProcessCodeOrderedRule<CrossingRuleExecutionContext> {
 
 	static final String KEY = "BACKCROSSSUFFIX";
-	static final String MALE_RECURRENT_SUFFIX = "BM";
-	static final String FEMALE_RECURRENT_SUFFIX = "BF";
+	static final String MALE_RECURRENT_SUFFIX = "M";
+	static final String FEMALE_RECURRENT_SUFFIX = "F";
 	static final String PROCESS_CODE = "[BC]";
 
 	@Override


### PR DESCRIPTION
This will update the behavior of [BC] according to the expected changes. BC should be resolved to M or F, not BM or BF. Tagging @matthewb22 