### PR TITLE
Bms 3759 separate label printing presets into planting and inventory

### DIFF
--- a/src/main/java/org/generationcp/commons/constant/ToolSection.java
+++ b/src/main/java/org/generationcp/commons/constant/ToolSection.java
@@ -5,5 +5,9 @@ package org.generationcp.commons.constant;
  * Created by cyrus on 12/19/14. Add specific tool sections here For now, this will be used specifically in presets
  */
 public enum ToolSection {
-	FBK_LABEL_PRINTING, FBK_CROSS_IMPORT, FB_LBL_PRINT_CUSTOM_REPORT, FB_NURSE_MGR_CUSTOM_REPORT, FB_TRIAL_MGR_CUSTOM_REPORT, BM_LIST_MGR_CUSTOM_REPORT
+	// Jasper Reports
+	FBK_CROSS_IMPORT, FB_LBL_PRINT_CUSTOM_REPORT, FB_NURSE_MGR_CUSTOM_REPORT, FB_TRIAL_MGR_CUSTOM_REPORT, BM_LIST_MGR_CUSTOM_REPORT,
+	
+	// Label printing presets
+	INVENTORY_LABEL_PRINTING_PRESET, PLANTING_LABEL_PRINTING_PRESET
 }


### PR DESCRIPTION
Risk Assessment: Medium, there's liquibase changes to alter the old data and few logic changes to separate the Inventory from the Planting label presets.

Kindly review. Thanks