### PR TITLE
Revert the code deleted in PR #164. This will fix the issue in Germpl…

### DIFF
--- a/src/main/java/org/generationcp/commons/util/WorkbenchAppPathResolver.java
+++ b/src/main/java/org/generationcp/commons/util/WorkbenchAppPathResolver.java
@@ -55,7 +55,10 @@ public class WorkbenchAppPathResolver {
 				appPath += "/openTrial/";
 			} else if (ToolName.NURSERY_MANAGER_FIELDBOOK_WEB.getName().equals(tool.getToolName())) {
 				appPath += "/editNursery/";
-			} 
+
+			} else if (tool.getToolName().equals(ToolName.GERMPLASM_BROWSER.getName())) {
+				appPath += "-";
+			}
 
 			appPath += idParam;
 		}


### PR DESCRIPTION
…asm Details popup not showing when GID or Designation Name links are clicked.

BMS-4599