### PR TITLE
IBP-2243 Compare study.createdBy against IbdbUserId

### DIFF
--- a/src/main/java/org/generationcp/commons/spring/util/ContextUtil.java
+++ b/src/main/java/org/generationcp/commons/spring/util/ContextUtil.java
@@ -109,4 +109,10 @@ public class ContextUtil {
 
 	}
 
+	public Integer getIbdbUserId(final Integer workbenchUserId) {
+		return this.workbenchDataManager
+			.getCurrentIbdbUserId(Long.valueOf(this.getProjectInContext().getProjectId().toString()), workbenchUserId);
+
+	}
+
 }


### PR DESCRIPTION
https://github.com/IntegratedBreedingPlatform/BMSAPI/pull/164
https://github.com/IntegratedBreedingPlatform/Fieldbook/pull/735
https://github.com/IntegratedBreedingPlatform/Commons/pull/202

Workbench user id does not always equals project.createdBy

See also BMS-886

Issue: IBP-2243
Reviewer: None