### PR TITLE
IBP-3971 Accept ISO-8601 date format in derived variables

### DIFF
--- a/src/main/java/org/generationcp/commons/derivedvariable/DerivedVariableUtils.java
+++ b/src/main/java/org/generationcp/commons/derivedvariable/DerivedVariableUtils.java
@@ -98,7 +98,6 @@ public final class DerivedVariableUtils {
 				// read from environment level.
 				if (environmentInputVariables.contains(termId)) {
 					observationUnitData = observationUnitRow.getEnvironmentVariables().get(termName);
-					convertEnvironmentDateVarToYYYYMMDDFormat(observationUnitData, measurementVariablesMap.get(observationUnitData.getVariableId()));
 				} else {
 					observationUnitData = observationUnitRow.getVariables().get(termName);
 				}
@@ -109,14 +108,6 @@ public final class DerivedVariableUtils {
 		}
 
 		return termMissingData;
-	}
-
-	static void convertEnvironmentDateVarToYYYYMMDDFormat(final ObservationUnitData data, final MeasurementVariable measurementVariable) throws ParseException{
-		if (DataType.DATE_TIME_VARIABLE.getId().equals(measurementVariable.getDataTypeId())) {
-			final Date date = DateUtil.parseDate(data.getValue(), Util.FRONTEND_DATE_FORMAT);
-			final String convertedDate = DateUtil.formatDateAsStringValue(date, Util.DATE_AS_NUMBER_FORMAT);
-			data.setValue(convertedDate);
-		}
 	}
 
 	private static Object getMeasurementValue(
@@ -146,6 +137,11 @@ public final class DerivedVariableUtils {
 
 		if (DataType.DATE_TIME_VARIABLE.getId().equals(measurementVariable.getDataTypeId())
 			&& !StringUtils.isBlank(value)) {
+			final Date dateISOFormat = Util.tryParseDate(value, Util.FRONTEND_DATE_FORMAT);
+			if (null != dateISOFormat) {
+				return dateISOFormat;
+			}
+			// we try one more format and else -> ParseException
 			return DateUtil.parseDate(value);
 		}
 		if (NumberUtils.isNumber(value)) {

--- a/src/test/java/org/generationcp/commons/derivedvariable/DerivedVariableProcessorTest.java
+++ b/src/test/java/org/generationcp/commons/derivedvariable/DerivedVariableProcessorTest.java
@@ -38,13 +38,15 @@ public class DerivedVariableProcessorTest {
 	private static final Integer TERM_2 = 50889; // GMoi_NIRS_pct - Grain moisture BY NIRS Moi - Measurement IN %
 	private static final Integer TERM_3 = 20358; // PlotArea_m2 - Plot size
 	private static final Integer TERM_4_EMPTY_VALUE = 20439; // MRFVInc_Cmp_pct
-	private static final Integer DATE_TERM1 = 8630;
-	private static final Integer DATE_TERM2 = 8830;
+	private static final Integer DATE_TERM1 = 8630; // GermiTest_date
+	private static final Integer DATE_TERM2 = 8830; // MecWeedCtrl_date
+	private static final Integer DATE_TERM3 = 8383; // SEEDING_DATE
 	private static final String TERM_VALUE_1 = "1000";
 	private static final String TERM_VALUE_2 = "12.5";
 	private static final String TERM_VALUE_3 = "10";
 	private static final String DATE_TERM1_VALUE = "20180101";
 	private static final String DATE_TERM2_VALUE = "20180201";
+	private static final String DATE_TERM3_VALUE = "2018-02-02";
 	private static final String TERM_NOT_FOUND = "TermNotFound";
 	private static final String FORMULA_1 = "({{" + TERM_1 + "}}/100)*((100-{{" + TERM_2 + "}})/(100-12.5))*(10/{{" + TERM_3 + "}})";
 	private static final String EXPECTED_FORMULA_1_RESULT = "10";
@@ -291,6 +293,17 @@ public class DerivedVariableProcessorTest {
 	}
 
 	@Test
+	public void testDaysDiffFunction_ISOFormat() throws ParseException {
+		String formula = "fn:daysdiff({{" + DATE_TERM1 + "}}, {{" + DATE_TERM3 + "}})";
+		final Map<String, Object> terms = extractParameters(formula);
+		extractValues(terms, this.createObservationUnitRowTestData(), this.createMeasurementVariablesMap(), new ArrayList<String>(), new ArrayList<String>());
+
+		formula = replaceDelimiters(formula);
+		final String result = this.processor.evaluateFormula(formula, terms);
+		Assert.assertEquals("32", result);
+	}
+
+	@Test
 	public void testDaysDiffFunctionNegativeDifference() throws ParseException {
 		// Having later date for first parameter should give negative value
 		String formula = "fn:daysdiff({{" + DATE_TERM2 + "}}, {{" + DATE_TERM1 + "}})";
@@ -372,7 +385,7 @@ public class DerivedVariableProcessorTest {
 	@Test(expected = ParseException.class)
 	public void testInvalidDateFormatParsing() throws ParseException {
 		final ObservationUnitRow testRow = this.createObservationUnitRowTestData();
-		testRow.getVariables().get("DATE_TERM2").setValue("2018-03-31");
+		testRow.getVariables().get("DATE_TERM2").setValue("03/31/2018");
 		final String formula = "({{" + DATE_TERM2 + "}}/100)";
 		final Map<String, Object> terms = extractParameters(formula);
 		extractValues(terms, testRow, this.createMeasurementVariablesMap(), new ArrayList<String>(), new ArrayList<String>());
@@ -399,6 +412,8 @@ public class DerivedVariableProcessorTest {
 			DataType.DATE_TIME_VARIABLE));
 		measurementVariablesMap.put(DATE_TERM2, this.createMeasurementVariable(DATE_TERM2, "DATE_TERM2",
 			DataType.DATE_TIME_VARIABLE));
+		measurementVariablesMap.put(DATE_TERM3, this.createMeasurementVariable(DATE_TERM3, "DATE_TERM3",
+			DataType.DATE_TIME_VARIABLE));
 		return measurementVariablesMap;
 
 	}
@@ -422,6 +437,8 @@ public class DerivedVariableProcessorTest {
 		observationUnitDataMap.put("DATE_TERM1", dateData1);
 		final ObservationUnitData dateData2 = this.createObservationUnitDataTestData(DATE_TERM2, DATE_TERM2_VALUE, null);
 		observationUnitDataMap.put("DATE_TERM2", dateData2);
+		final ObservationUnitData dateData3 = this.createObservationUnitDataTestData(DATE_TERM3, DATE_TERM3_VALUE, null);
+		observationUnitDataMap.put("DATE_TERM3", dateData3);
 		return observationUnitDataMap;
 	}
 

--- a/src/test/java/org/generationcp/commons/derivedvariable/DerivedVariableUtilsTest.java
+++ b/src/test/java/org/generationcp/commons/derivedvariable/DerivedVariableUtilsTest.java
@@ -468,17 +468,6 @@ public class DerivedVariableUtilsTest {
 
 	}
 
-	@Test
-	public void testConvertEnvironmentDateVarToYYYYMMDDFormat() throws ParseException {
-		final ObservationUnitData data = this.createObservationUnitDataTestData(TermId.DATE_VARIABLE.getId(), "2019-08-21", null);
-		final MeasurementVariable measurementVariable = new MeasurementVariable();
-		measurementVariable.setTermId(TermId.DATE_VARIABLE.getId());
-		measurementVariable.setDataTypeId(DataType.DATE_TIME_VARIABLE.getId());
-
-		DerivedVariableUtils.convertEnvironmentDateVarToYYYYMMDDFormat(data, measurementVariable);
-		Assert.assertEquals("20190821", data.getValue());
-	}
-
 	private ObservationUnitData createObservationUnitDataTestData(final Integer VARIABLE_ID, final String value, final Integer cValueId) {
 		final ObservationUnitData observationUnitData = new ObservationUnitData();
 		observationUnitData.setVariableId(VARIABLE_ID);


### PR DESCRIPTION
Reverts fff541a909184cbfe10cb7e38752ff56b303e530

The date format in the environments tab used to be ISO-8601 (yyyy-mm-dd), but after IBP-3303 (environments API re-engineering) it was changed to numeric format (yyyymmmdd).
However, there's no migration so we can still find studies with the old format.
Make the `DerivedVariableUtils` accept both formats no matter where the data is coming from.
