### PR TITLE
IBP-5223: allow blob: frame source in CSP config

### DIFF
--- a/src/main/java/org/generationcp/commons/hibernate/HTTPRequestAwareServletFilter.java
+++ b/src/main/java/org/generationcp/commons/hibernate/HTTPRequestAwareServletFilter.java
@@ -36,6 +36,7 @@ public class HTTPRequestAwareServletFilter implements Filter {
 	private static final Logger LOG = LoggerFactory.getLogger(HTTPRequestAwareServletFilter.class);
 	public static final String CSP_CONFIG = "default-src 'self'; "
 		+ "img-src 'self' data: https:; "
+		+ "frame-src 'self' blob:; "
 		+ "connect-src 'self' https:; "
 		+ "object-src 'none'; "
 		+ "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "


### PR DESCRIPTION
- prevents firefox error when trying to export csv/excel