### PR TITLE
IBP-6228, IBP-6193 PATCH: Use controller/jhipster (no absolute redirect)

### DIFF
--- a/src/main/java/org/generationcp/commons/constant/DefaultGermplasmStudyBrowserPath.java
+++ b/src/main/java/org/generationcp/commons/constant/DefaultGermplasmStudyBrowserPath.java
@@ -9,6 +9,6 @@ public interface DefaultGermplasmStudyBrowserPath {
 	String LIST_BROWSER_LINK = "ibpworkbench/maingpsb/germplasmlist-";
 	String STUDY_BROWSER_LINK = "ibpworkbench/maingpsb/study-";
 	String GRAPHICAL_FILTERING_TOOL_LINK = "/ibpworkbench/controller/graphical-filtering?studyDbId=%s&crop=%s&restartApplication";
-	String GERMPLASM_DETAILS_LINK = "/ibpworkbench/main/app/#/germplasm-details/";
+	String GERMPLASM_DETAILS_LINK = "/ibpworkbench/controller/jhipster#/germplasm-details/";
 
 }


### PR DESCRIPTION
Avoid problems with JHipsterController redirect /app/ to /main/, causing absolute redirect in iframe in some servers.